### PR TITLE
Matryoshka SAE implementation

### DIFF
--- a/hypothesaes/sae.py
+++ b/hypothesaes/sae.py
@@ -1,177 +1,248 @@
-"""Sparse autoencoder implementation and training."""
+"""Top-K sparse autoencoder implementation and training.
 
+Implementation details:
+1. Matryoshka loss: average the loss computed with increasing prefixes of neurons.
+2. Auxiliary-K reconstruction: revive dead neurons.
+3. Multi-K reconstruction: use a slightly less sparse reconstruction with lower weight.
+
+Our implementation draws from:
+- Bussmann et al. (2025) https://github.com/bartbussmann/matryoshka_sae/blob/main/sae.py (for Matryoshka loss)
+- O'Neill et al. (2024) https://github.com/Christine8888/saerch/blob/main/saerch/topk_sae.py (for top-K with dead neuron revival)
+"""
+
+import os
+import pickle
+from typing import Optional, Tuple, Dict, List
+
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader, TensorDataset
-import numpy as np
-from typing import Optional, Tuple, Dict
 from tqdm.auto import tqdm
-import os
-import pickle
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
+
+# ----------------------------------------------------------------------------
+# Sparse Autoencoder with optional Matryoshka loss
+# ----------------------------------------------------------------------------
+
 class SparseAutoencoder(nn.Module):
     def __init__(
-        self, 
+        self,
         input_dim: int,
         m_total_neurons: int,
         k_active_neurons: int,
-        aux_k: Optional[int] = None, # Number of neurons to consider for dead neuron revival
-        multi_k: Optional[int] = None, # Number of neurons for secondary reconstruction
-        dead_neuron_threshold_steps: int = 256 # Number of non-firing steps after which a neuron is considered dead
-    ):
+        *,
+        aux_k: Optional[int] = None,
+        multi_k: Optional[int] = None,
+        dead_neuron_threshold_steps: int = 256,
+        prefix_group_sizes: Optional[List[int]] = None,
+    ) -> None:
+        """Create a top-K sparse autoencoder.
+
+        Parameters
+        ----------
+        input_dim : int
+            Dimensionality of the input representations.
+        m_total_neurons : int
+            Total number of neurons (SAE features).
+        k_active_neurons : int
+            Number of active neurons selected per example.
+        aux_k : int | None, optional
+            Upper bound on the number of dead neurons to try for auxiliary residual prediction.
+        multi_k : int | None, optional
+            How many neurons to use for the less‑sparse multi‑K reconstruction
+            term.  The default weight on this loss is 0. If *None* it defaults to 
+            `4 * k_active_neurons` (capped at `m_total_neurons`).
+        dead_neuron_threshold_steps : int, optional
+            Steps of non‑activation after which a neuron counts as *dead*.
+        prefix_group_sizes : list[int] | None, optional
+            If given (e.g. `[16, 48]`), activates *Matryoshka* loss: the first
+            prefix has 16 neurons, the second another 48, etc.  If *None*, all
+            M neurons are treated equally.
+        """
+
         super().__init__()
         self.input_dim = input_dim
         self.m_total_neurons = m_total_neurons
         self.k_active_neurons = k_active_neurons
-        self.aux_k = min(2 * k_active_neurons, m_total_neurons) if aux_k is None else aux_k
-        self.multi_k = min(4 * k_active_neurons, m_total_neurons) if multi_k is None else multi_k
+
+        # Fallback defaults ---------------------------------------------------
+        self.aux_k = (
+            min(2 * k_active_neurons, m_total_neurons) if aux_k is None else aux_k
+        )
+        self.multi_k = multi_k
         self.dead_neuron_threshold_steps = dead_neuron_threshold_steps
 
-        # Core layers
+        # Matryoshka groups ----------------------------------------------------
+        if prefix_group_sizes is None:
+            prefix_group_sizes = [m_total_neurons]
+        assert (
+            sum(prefix_group_sizes) == m_total_neurons
+        ), "sum(prefix_group_sizes) must equal m_total_neurons"
+        self.prefix_group_sizes = prefix_group_sizes
+        # Index boundaries for each Matryoshka prefix
+        self.prefix_boundaries = torch.tensor(np.cumsum(prefix_group_sizes), device=device)
+
+        # weight initialization --------------------------------------------------------------
         self.encoder = nn.Linear(input_dim, m_total_neurons, bias=False)
         self.decoder = nn.Linear(m_total_neurons, input_dim, bias=False)
-        
-        # Biases as separate parameters
+
         self.input_bias = nn.Parameter(torch.zeros(input_dim))
         self.neuron_bias = nn.Parameter(torch.zeros(m_total_neurons))
-        
-        # Tracking dead neurons
-        self.steps_since_activation = torch.zeros(m_total_neurons, dtype=torch.long, device=device)
 
-        # Put model on correct device
+        # dead‑neuron bookkeeping --------------------------------------------
+        self.steps_since_activation = torch.zeros(
+            m_total_neurons, dtype=torch.long, device=device
+        )
+
         self.to(device)
 
+    # ---------------------------------------------------------------------
+    # Forward pass (agnostic to Matryoshka configuration)
+    # ---------------------------------------------------------------------
     def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, Dict]:
-        # Center input
+        # W_enc(x - b_pre) + b_enc
         x = x - self.input_bias
         pre_act = self.encoder(x) + self.neuron_bias
-        
-        # Main top-k activation
-        topk_values, topk_indices = torch.topk(pre_act, k=self.k_active_neurons, dim=-1)
-        topk_values = F.relu(topk_values)
-        
-        # Multi-k activation for loss computation
-        multik_values, multik_indices = torch.topk(pre_act, k=self.multi_k, dim=-1)
-        multik_values = F.relu(multik_values)
-        
-        # Create sparse activation tensors
-        activations = torch.zeros_like(pre_act)
-        activations.scatter_(-1, topk_indices, topk_values)
-        
-        multik_activations = torch.zeros_like(pre_act)
-        multik_activations.scatter_(-1, multik_indices, multik_values)
-        
-        # Update dead neuron tracking
+
+        # main Top‑K ---------------------------------------------------------
+        topk_vals, topk_idx = torch.topk(pre_act, self.k_active_neurons, dim=-1)
+        topk_vals = F.relu(topk_vals)
+        activ = torch.zeros_like(pre_act)
+        activ.scatter_(-1, topk_idx, topk_vals)
+
+        # multi‑K --------------------------------------------------
+        if self.multi_k is not None:
+            multik_vals, multik_idx = torch.topk(pre_act, self.multi_k, dim=-1)
+            multik_vals = F.relu(multik_vals)
+            multik_activ = torch.zeros_like(pre_act)
+            multik_activ.scatter_(-1, multik_idx, multik_vals)
+            multik_recon = self.decoder(multik_activ) + self.input_bias
+        else:
+            multik_recon = None
+
+        # dead‑neuron tracking
         self.steps_since_activation += 1
-        self.steps_since_activation.scatter_(0, topk_indices.unique(), 0)
-        
-        # Compute reconstructions
-        reconstruction = self.decoder(activations) + self.input_bias
-        multik_reconstruction = self.decoder(multik_activations) + self.input_bias
-        
-        # Handle auxiliary dead neuron revival
-        aux_values, aux_indices = None, None
+        self.steps_since_activation.scatter_(0, topk_idx.unique(), 0)
+
+        # reconstructions ----------------------------------------------------
+        recon = self.decoder(activ) + self.input_bias
+
+        # aux‑K --------------------------------------------------------------
+        aux_idx = aux_vals = None
         if self.aux_k is not None:
             dead_mask = (self.steps_since_activation > self.dead_neuron_threshold_steps).float()
-            dead_neuron_pre_act = pre_act * dead_mask
-            aux_values, aux_indices = torch.topk(dead_neuron_pre_act, k=self.aux_k, dim=-1)
-            aux_values = F.relu(aux_values)
-            
-        return reconstruction, {
-            "activations": activations,
-            "topk_indices": topk_indices,
-            "topk_values": topk_values,
-            "multik_reconstruction": multik_reconstruction,
-            "aux_indices": aux_indices,
-            "aux_values": aux_values,
+            dead_pre_act = pre_act * dead_mask
+            aux_vals, aux_idx = torch.topk(dead_pre_act, self.aux_k, dim=-1)
+            aux_vals = F.relu(aux_vals)
+
+        info = {
+            "activations": activ,  # needed for Matryoshka slices
+            "topk_indices": topk_idx,
+            "topk_values": topk_vals,
+            "multik_reconstruction": multik_recon,
+            "aux_indices": aux_idx,
+            "aux_values": aux_vals,
         }
+        return recon, info
 
-    def reconstruct_input_from_latents(self, indices: torch.Tensor, values: torch.Tensor) -> torch.Tensor:
-        """Reconstruct the input from the sparse latent representation.
-        Inputs:
-            indices: Tensor of indices of active neurons
-            values: Tensor of values of active neurons
-        Returns:
-            Reconstructed input tensor
-        """
-        activations = torch.zeros(self.m_total_neurons, device=indices.device)
-        activations.scatter_(-1, indices, values)
-        return self.decoder(activations) + self.input_bias
-
-    def normalize_decoder_(self):
-        """Normalize decoder weights to unit norm in-place."""
-        with torch.no_grad():
-            self.decoder.weight.div_(self.decoder.weight.norm(dim=0, keepdim=True))
-
-    def adjust_decoder_gradient_(self):
-        """Adjust decoder gradient to maintain unit norm constraint."""
-        if self.decoder.weight.grad is not None:
-            with torch.no_grad():
-                proj = torch.sum(self.decoder.weight * self.decoder.weight.grad, dim=0, keepdim=True)
-                self.decoder.weight.grad.sub_(proj * self.decoder.weight)
-
-    def initialize_weights_(self, data_sample: torch.Tensor):
-        """Initialize parameters from data statistics."""
-        # Initialize bias to median of data -- See O'Neill et al. (2024) Appendix A.1
-        self.input_bias.data = torch.median(data_sample, dim=0).values 
-        nn.init.xavier_uniform_(self.decoder.weight)
-        self.normalize_decoder_()
-        self.encoder.weight.data = self.decoder.weight.t().clone()
-        nn.init.zeros_(self.neuron_bias)
-
-    def save(self, save_path: str):
-        """Save model state dict and config to specified directory."""
-        os.makedirs(os.path.dirname(save_path), exist_ok=True)
-        
-        config = {
-            'input_dim': self.input_dim,
-            'm_total_neurons': self.m_total_neurons,
-            'k_active_neurons': self.k_active_neurons,
-            'aux_k': self.aux_k,
-            'multi_k': self.multi_k,
-            'dead_neuron_threshold_steps': self.dead_neuron_threshold_steps
-        }
-        
-        torch.save({
-            'config': config,
-            'state_dict': self.state_dict()
-        }, save_path, pickle_module=pickle)
-        print(f"Saved model to {save_path}")
-
-        return save_path
-
+    # ------------------------------------------------------------------
+    # Loss with optional Matryoshka terms
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalized_mse(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        mse = F.mse_loss(pred, target)
+        baseline_mse = F.mse_loss(target.mean(dim=0, keepdim=True).expand_as(target), target)
+        return mse / baseline_mse
+    
     def compute_loss(
         self,
         x: torch.Tensor,
         recon: torch.Tensor,
         info: Dict[str, torch.Tensor],
-        aux_coef: float = 1/32,
-        multi_coef: float = 0.0
+        aux_coef: float,
+        multi_coef: float,
     ) -> torch.Tensor:
-        """Compute SAE loss with auxiliary terms."""
-        def normalized_mse(pred, target):
-            mse = F.mse_loss(pred, target)
-            baseline_mse = F.mse_loss(target.mean(dim=0, keepdim=True).expand_as(target), target)
-            return mse / baseline_mse
-        
-        recon_loss = normalized_mse(recon, x)
-        recon_loss += multi_coef * normalized_mse(info["multik_reconstruction"], x)
-        
-        if self.aux_k is not None:
-            error = x - recon.detach()
-            aux_activations = torch.zeros_like(info["activations"])
-            aux_activations.scatter_(-1, info["aux_indices"], info["aux_values"])
-            error_reconstruction = self.decoder(aux_activations)
-            aux_loss = normalized_mse(error_reconstruction, error)
-            total_loss = recon_loss + aux_coef * aux_loss
-        else:
-            total_loss = recon_loss
-            
-        return total_loss
+        """Return total loss (Matryoshka L2 + optional multi‑K + aux).
 
+        If `len(prefix_group_sizes)==1` there is no Matryoshka nesting.
+        Otherwise we average the L2 of every prefix reconstruction as in
+        Bussmann et al. (2025).
+
+        multiK / auxK implemented as in O'Neill et al. (2024).
+        """
+
+        activ = info["activations"]
+        # main L2 -----------------------------------------------------------
+        if len(self.prefix_group_sizes) == 1:
+            main_l2 = self._normalized_mse(recon, x)
+        else:
+            l2_terms = []
+            dec_weight = self.decoder.weight  # (input_dim, m_total_neurons)
+            for end in self.prefix_boundaries:  # skip leading 0
+                # activ[:, :end] is (batchsize, end);  dec_weight[:, :end] is (input_dim, end)
+                prefix_recon = activ[:, :end] @ dec_weight[:, :end].t() + self.input_bias
+                l2_terms.append(self._normalized_mse(prefix_recon, x))
+            main_l2 = torch.stack(l2_terms).mean()
+
+        # multi‑K term ------------------------------------------------------
+        if multi_coef != 0 and info["multik_reconstruction"] is not None:
+            main_l2 = main_l2 + multi_coef * self._normalized_mse(
+                info["multik_reconstruction"], x
+            )
+
+        # aux‑K term --------------------------------------------------------
+        if self.aux_k is not None and info["aux_indices"] is not None:
+            err = x - recon.detach()
+            aux_act = torch.zeros_like(activ)
+            aux_act.scatter_(-1, info["aux_indices"], info["aux_values"])
+            err_recon = self.decoder(aux_act)
+            aux_loss = self._normalized_mse(err_recon, err)
+            return main_l2 + aux_coef * aux_loss
+        else:
+            return main_l2
+
+    # ------------------------------------------------------------------
+    # Utility helpers for training
+    # ------------------------------------------------------------------
+    def normalize_decoder_(self):
+        with torch.no_grad():
+            self.decoder.weight.div_(self.decoder.weight.norm(dim=0, keepdim=True))
+
+    def adjust_decoder_gradient_(self):
+        if self.decoder.weight.grad is not None:
+            with torch.no_grad():
+                proj = (self.decoder.weight * self.decoder.weight.grad).sum(dim=0, keepdim=True)
+                self.decoder.weight.grad.sub_(proj * self.decoder.weight)
+
+    def initialize_weights_(self, data_sample: torch.Tensor):
+        self.input_bias.data = torch.median(data_sample, dim=0).values
+        nn.init.xavier_uniform_(self.decoder.weight)
+        self.normalize_decoder_()
+        self.encoder.weight.data = self.decoder.weight.t().clone()
+        nn.init.zeros_(self.neuron_bias)
+        
+    def save(self, save_path: str):
+        os.makedirs(os.path.dirname(save_path), exist_ok=True)
+        config = {
+            "input_dim": self.input_dim,
+            "m_total_neurons": self.m_total_neurons,
+            "k_active_neurons": self.k_active_neurons,
+            "aux_k": self.aux_k,
+            "multi_k": self.multi_k,
+            "dead_neuron_threshold_steps": self.dead_neuron_threshold_steps,
+            "prefix_group_sizes": self.prefix_group_sizes,
+        }
+        torch.save({"config": config, "state_dict": self.state_dict()}, save_path, pickle_module=pickle)
+        print(f"Saved model to {save_path}")
+        return save_path
+
+    # ------------------------------------------------------------------
+    # Training loop
+    # ------------------------------------------------------------------
     def fit(
         self,
         X_train: torch.Tensor,
@@ -180,7 +251,7 @@ class SparseAutoencoder(nn.Module):
         batch_size: int = 512,
         learning_rate: float = 5e-4,
         n_epochs: int = 200,
-        aux_coef: float = 1/32,
+        aux_coef: float = 1 / 32,
         multi_coef: float = 0.0,
         patience: int = 5,
         show_progress: bool = True,
@@ -266,10 +337,14 @@ class SparseAutoencoder(nn.Module):
         # Save final model
         if save_dir is not None:
             os.makedirs(save_dir, exist_ok=True)
-            self.save(os.path.join(save_dir, f'SAE_M={self.m_total_neurons}_K={self.k_active_neurons}.pt'))
+            filename = get_sae_checkpoint_name(self.m_total_neurons, self.k_active_neurons, self.prefix_group_sizes)
+            self.save(os.path.join(save_dir, filename))
             
         return history
-
+    
+    # ------------------------------------------------------------------
+    # Compute activations with batched SAE inference
+    # ------------------------------------------------------------------
     def get_activations(self, inputs, batch_size=16384, show_progress=True):
         """Get sparse activations for input data with batching to prevent CUDA OOM.
         
@@ -308,11 +383,20 @@ class SparseAutoencoder(nn.Module):
         
         return torch.cat(all_activations, dim=0).numpy()
 
+# -----------------------------------------------------------------------------
+# Additional utils
+# -----------------------------------------------------------------------------
+def get_sae_checkpoint_name(m_total_neurons, k_active_neurons, prefix_group_sizes=None):
+    if prefix_group_sizes is None:
+        return f'SAE_M={m_total_neurons}_K={k_active_neurons}.pt'
+    else:
+        group_str = "-".join(str(g) for g in prefix_group_sizes)
+        return f'SAE_matryoshka_M={m_total_neurons}_K={k_active_neurons}_groups={group_str}.pt'
+
 def load_model(path: str) -> SparseAutoencoder:
-    """Load a saved model from path."""
-    checkpoint = torch.load(path, pickle_module=pickle)
-    model = SparseAutoencoder(**checkpoint['config'])
-    model.load_state_dict(checkpoint['state_dict'])
+    ckpt = torch.load(path, pickle_module=pickle)
+    model = SparseAutoencoder(**ckpt["config"])
+    model.load_state_dict(ckpt["state_dict"])
     print(f"Loaded model from {path}")
     return model
 

--- a/hypothesaes/sae.py
+++ b/hypothesaes/sae.py
@@ -52,10 +52,13 @@ class SparseAutoencoder(nn.Module):
             Number of active neurons selected per example.
         aux_k : int | None, optional
             Upper bound on the number of dead neurons to try for auxiliary residual prediction.
+            The default value, set during initialization, is `2 * k_active_neurons`.
+            The default coefficient on the auxiliary loss is 1/32 (see `compute_loss`).
         multi_k : int | None, optional
             How many neurons to use for the less‑sparse multi‑K reconstruction
-            term.  The default weight on this loss is 0. If *None* it defaults to 
-            `4 * k_active_neurons` (capped at `m_total_neurons`).
+            term.  The default weight on this loss is 0, and the default value
+            is None (i.e. no multi‑K reconstruction).  If using, a recommend starting 
+            value is `4 * k_active_neurons`.
         dead_neuron_threshold_steps : int, optional
             Steps of non‑activation after which a neuron counts as *dead*.
         prefix_group_sizes : list[int] | None, optional

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -12,6 +12,7 @@ from hypothesaes import (
     generate_hypotheses,
     evaluate_hypotheses
 )
+from hypothesaes.sae import get_sae_checkpoint_name, load_model
 
 from hypothesaes.llm_api import get_completion
 
@@ -72,12 +73,20 @@ ALL_SENTENCES = BLUE_OBJECTS + RED_OBJECTS
 # Labels: 0 for blue objects, 1 for red objects
 LABELS = [0] * len(BLUE_OBJECTS) + [1] * len(RED_OBJECTS)
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def test_data():
-    """Return test data for the tests."""
+    """Return test data and precomputed local embeddings to use across all tests."""
+    sentences = ALL_SENTENCES
+    labels = LABELS
+
+    # Compute local embeddings (MiniLM)
+    local_emb_dict = get_local_embeddings(texts=sentences, model=LOCAL_MODEL_TESTING, show_progress=False)
+    local_embeddings = np.array([local_emb_dict[text] for text in sentences])
+
     return {
-        "sentences": ALL_SENTENCES,
-        "labels": LABELS
+        "sentences": sentences,
+        "labels": labels,
+        "local_embeddings": local_embeddings,
     }
 
 def test_openai_client():
@@ -93,59 +102,39 @@ def test_openai_client():
 def test_compute_openai_embeddings(test_data):
     """Test computing embeddings using OpenAI models."""
     sentences = test_data["sentences"]
-    
-    openai_emb_dict = get_openai_embeddings(
-        texts=sentences,
-        model=OPENAI_MODEL_TESTING, 
-        show_progress=False
-    )
-    
+    openai_emb_dict = get_openai_embeddings(texts=sentences, model=OPENAI_MODEL_TESTING, show_progress=False, n_workers=1)
     openai_embeddings = np.array([openai_emb_dict[text] for text in sentences])
-    assert openai_embeddings.shape == (40, 1536), f"OpenAI embeddings shape is {openai_embeddings.shape}, expected (40, 1536)"
+    assert openai_embeddings.shape == (len(ALL_SENTENCES), 1536), f"OpenAI embeddings shape is {openai_embeddings.shape}, expected ({len(ALL_SENTENCES)}, 1536)"
 
 def test_compute_local_embeddings(test_data):
-    """Test computing embeddings using local sentence-transformer models."""
-    sentences = test_data["sentences"]
-    
-    local_emb_dict = get_local_embeddings(
-        texts=sentences,
-        model=LOCAL_MODEL_TESTING,
-        show_progress=False
-    )
-    
-    local_embeddings = np.array([local_emb_dict[text] for text in sentences])
-    assert local_embeddings.shape == (40, 384), f"Local embeddings shape is {local_embeddings.shape}, expected (40, 384)"
+    """Test local embeddings shape."""
+    local_embeddings = test_data["local_embeddings"]
+    assert local_embeddings.shape == (len(ALL_SENTENCES), 384), f"Local embeddings shape is {local_embeddings.shape}, expected ({len(ALL_SENTENCES)}, 384)"
 
 def test_train_sae(test_data):
-    """Test training SAEs with different configurations."""
-    sentences = test_data["sentences"]
+    """Test training, saving, and loading SAEs with different configurations."""
+    M, K = 2, 1
+    checkpoint_dir = "./"
+    _ = train_sae(test_data["local_embeddings"], M, K, n_epochs=3, checkpoint_dir=checkpoint_dir)
     
-    emb_dict = get_local_embeddings(
-        texts=sentences,
-        model=LOCAL_MODEL_TESTING,
-        show_progress=False
-    )
-    embeddings = np.array([emb_dict[text] for text in sentences])
+    checkpoint_path = os.path.join(checkpoint_dir, get_sae_checkpoint_name(M, K))
+    assert os.path.exists(checkpoint_path)
+    _ = load_model(checkpoint_path)
+    os.remove(checkpoint_path)
 
-    sae = train_sae(embeddings=embeddings, M=2, K=1, n_epochs=5)
+def test_train_matryoshka_sae(test_data):
+    """Test training a Matryoshka SAE (with multiple prefix lengths)."""
+    matryoshka_prefix_lengths = [2, 4]
+    sae = train_sae(embeddings=test_data["local_embeddings"], M=4, K=1, matryoshka_prefix_lengths=matryoshka_prefix_lengths, n_epochs=3)
+    assert sae.prefix_lengths == matryoshka_prefix_lengths
 
 def test_interpret_sae(test_data):
     """Test interpreting neurons from trained SAEs."""
     sentences = test_data["sentences"]
-    
-    # Get local embeddings
-    emb_dict = get_local_embeddings(
-        texts=sentences,
-        model=LOCAL_MODEL_TESTING,
-        show_progress=False
-    )
-    
-    embeddings = np.array([emb_dict[text] for text in sentences])
-    
-    # Train SAEs
-    sae_small = train_sae(embeddings=embeddings, M=2, K=1, n_epochs=5)
-    sae_large = train_sae(embeddings=embeddings, M=4, K=2, n_epochs=5)
-    
+    embeddings = test_data["local_embeddings"]
+    sae_small = train_sae(embeddings=embeddings, M=2, K=1, n_epochs=3)
+    sae_large = train_sae(embeddings=embeddings, M=4, K=2, n_epochs=3)
+
     # Test interpret_sae with both SAEs
     interpretations = interpret_sae(
         texts=sentences,
@@ -157,8 +146,6 @@ def test_interpret_sae(test_data):
         n_examples_for_interpretation=10,  # Small number for testing
         print_examples_n=3
     )
-    
-    # Verify results structure
     assert len(interpretations) > 0
     assert "neuron_idx" in interpretations.columns
     assert "interpretation" in interpretations.columns
@@ -167,20 +154,10 @@ def test_generate_and_evaluate_hypotheses(test_data):
     """Test generating and evaluating hypotheses."""
     sentences = test_data["sentences"]
     labels = test_data["labels"]
-    
-    # Get local embeddings
-    emb_dict = get_local_embeddings(
-        texts=sentences,
-        model=LOCAL_MODEL_TESTING,
-        show_progress=False
-    )
-    
-    embeddings = np.array([emb_dict[text] for text in sentences])
-    
-    # Train SAEs
-    sae_small = train_sae(embeddings=embeddings, M=2, K=1, n_epochs=5)
-    sae_large = train_sae(embeddings=embeddings, M=4, K=2, n_epochs=5)
-    
+    embeddings = test_data["local_embeddings"]
+    sae_small = train_sae(embeddings=embeddings, M=2, K=1, n_epochs=3)
+    sae_large = train_sae(embeddings=embeddings, M=4, K=2, n_epochs=3)
+
     # Generate hypotheses
     hypotheses_df = generate_hypotheses(
         texts=sentences,
@@ -200,9 +177,8 @@ def test_generate_and_evaluate_hypotheses(test_data):
     assert len(hypotheses_df) > 0
     assert "neuron_idx" in hypotheses_df.columns
     assert "interpretation" in hypotheses_df.columns
-
     print(hypotheses_df)
-    
+
     # Evaluate hypotheses
     metrics, evaluation_df = evaluate_hypotheses(
         hypotheses_df=hypotheses_df,
@@ -216,5 +192,4 @@ def test_generate_and_evaluate_hypotheses(test_data):
     assert len(evaluation_df) > 0
     assert "hypothesis" in evaluation_df.columns
     assert "regression_coef" in evaluation_df.columns 
-
     print(evaluation_df)


### PR DESCRIPTION
Modifies our vanilla Top-K SAEs to allow for a Matryoshka-style loss. 

In this setup, we compute multiple reconstructions of the input using widening prefixes of the SAE neurons, and average each of these reconstruction losses. This encourages the SAE to learn high-fidelity reconstructions at multiple scales, from coarse to increasingly granular.

For implementation, see the new parameters in the `SparseAutoencoder` constructor or the parameter in `quickstart.train_sae()`.

More details can be found in [Bussman et al. 2025](https://arxiv.org/abs/2503.17547). (Our SAE isn't identical, but it follows the same approach for the Matryoshka component.)

Note that we haven't re-run the paper's experiments using MSAEs, so this should be considered a beta implementation!