### PR TITLE
Updated separation score metric & added additional annotation functionality

### DIFF
--- a/hypothesaes/annotate.py
+++ b/hypothesaes/annotate.py
@@ -1,13 +1,15 @@
 """Text annotation using LLM-based concept checking."""
 
 import numpy as np
-from typing import List, Optional, Dict, Tuple
+from typing import List, Optional, Dict, Tuple, Callable
 import concurrent.futures
 from tqdm.auto import tqdm
 import os
 import json
 from pathlib import Path
 import time
+import re
+import json
 
 from .llm_api import get_completion, normalize_llm_kwargs
 from .utils import load_prompt, truncate_text
@@ -56,11 +58,32 @@ def parse_completion(completion: str) -> int:
         completion = completion.split('</think>')[1].strip()
     return 1 if completion.startswith("yes") else 0 if completion.startswith("no") else None
 
+def parse_completion_json(completion: str) -> Optional[int]:
+    """Parse a JSON completion into an annotation.
+    
+    Returns 1 for "yes", 0 for "no", -1 for "not_found", None if parsing fails.
+    """
+    if '</think>' in completion:
+        completion = completion.split('</think>')[1].strip()
+    match = re.search(r'\{.*\}', completion, re.DOTALL)
+    if not match:
+        return None
+    try:
+        cleaned = re.sub(r'\\(?!["\\/bfnrt]|u[0-9a-fA-F]{4})', '', match.group(0))
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError:
+        return None
+
+    answer = parsed.get("answer", "").strip().lower()
+    return 1 if answer == "yes" else 0 if answer == "no" else None
+
 def annotate_single_text(
     text: str,
     concept: str,
     annotate_prompt_name: str = "annotate",
     model: str = "gpt-5-mini",
+    parse_fn: Callable[[str], int] = parse_completion,
+    system_prompt_name: Optional[str] = None,
     max_words_per_example: Optional[int] = None,
     temperature: Optional[float] = None,
     max_output_tokens: Optional[int] = None,
@@ -78,6 +101,7 @@ def annotate_single_text(
         text = truncate_text(text, max_words_per_example)
         
     annotate_prompt = load_prompt(annotate_prompt_name)
+    system_prompt = load_prompt(system_prompt_name) if system_prompt_name is not None else None
     prompt = annotate_prompt.format(hypothesis=concept, text=text)
     
     total_api_time = 0.0
@@ -100,11 +124,12 @@ def annotate_single_text(
 
             response_text = get_completion(
                 prompt=prompt,
+                system_prompt=system_prompt,
                 **request_kwargs
             ).strip().lower()
             total_api_time += time.time() - start_time
             
-            annotation = parse_completion(response_text)
+            annotation = parse_fn(response_text)
             if annotation is not None:
                 return annotation, total_api_time
             
@@ -122,6 +147,8 @@ def _parallel_annotate(
     n_workers: int,
     results: Dict[str, Dict[str, int]],
     cache: Optional[dict] = None,
+    cache_path: Optional[str] = None,
+    checkpoint_every: int = 1000,
     progress_desc: str = "Annotating",
     show_progress: bool = True,
     **annotation_kwargs
@@ -140,13 +167,17 @@ def _parallel_annotate(
                        total=len(tasks),
                        desc=progress_desc,
                        disable=not show_progress)
-        
+
+        completed = 0
         for future in iterator:
             text, concept = future_to_task[future]
             try:
                 annotation, _ = future.result()
                 if annotation is not None:
                     _store_annotation(results, concept, text, annotation, cache)
+                completed += 1
+                if completed % checkpoint_every == 0 and cache_path is not None:
+                    save_annotation_cache(cache_path, cache)
             except Exception as e:
                 retry_tasks.append((text, concept))
                 print(f"Failed to annotate text for concept '{concept}': {e}")
@@ -221,6 +252,7 @@ def annotate(
             model=model,
             n_workers=n_workers,
             cache=cache,
+            cache_path=cache_path,
             results=results,
             show_progress=show_progress,
             progress_desc=progress_desc,

--- a/hypothesaes/llm_api.py
+++ b/hypothesaes/llm_api.py
@@ -153,6 +153,7 @@ def get_completion(
     prompt: Optional[str] = None,
     *,
     messages: Optional[List[Dict[str, Any]]] = None,
+    system_prompt: Optional[str] = None,
     model: str = DEFAULT_MODEL,
     timeout: Optional[float] = None,
     max_retries: int = 3,
@@ -200,7 +201,22 @@ def get_completion(
         reasoning_payload["effort"] = reasoning_effort
         kwargs["reasoning"] = reasoning_payload
 
-    request_input = messages if messages is not None else prompt
+    if messages is not None:
+        if system_prompt is not None:
+            has_system = any(m.get("role") == "system" for m in messages)
+            if has_system:
+                raise ValueError("system_prompt was provided, but messages already contains a system message")
+            request_input = [{"role": "system", "content": system_prompt}, *messages]
+        else:
+            request_input = messages
+    else:
+        if system_prompt is not None:
+            request_input = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ]
+        else:
+            request_input = prompt
 
     base_wait = timeout if timeout is not None else 1.0
     for attempt in range(max_retries):

--- a/hypothesaes/prompts/annotate-system-json.txt
+++ b/hypothesaes/prompts/annotate-system-json.txt
@@ -1,0 +1,39 @@
+You are an expert annotator. Your task is to determine whether a TEXT exhibits a given PROPERTY.
+
+Rules:
+- Output valid JSON only, matching the schema below.
+- "answer" must be exactly "yes" or "no"
+- "reasoning" must be one sentence citing specific evidence (or its absence) from the TEXT.
+
+Schema:
+{"answer": "yes" | "no", "reasoning": "<one sentence>"}
+
+Examples:
+
+PROPERTY: "mentions a natural scene."
+TEXT: "I love the way the sun sets in the evening."
+Output: {"answer": "yes", "reasoning": "Sunsets are clearly natural scenes."}
+
+PROPERTY: "writes in a 1st person perspective."
+TEXT: "Jacob is smart."
+Output: {"answer": "no", "reasoning": "This text is written in a 3rd person perspective."}
+
+PROPERTY: "is better than group B."
+TEXT: "I also need to buy a chair."
+Output: {"answer": "no", "reasoning": "It is unclear what the PROPERTY means (e.g., what does group B mean?) and doesn't seem related to the text."}
+
+PROPERTY: "mentions that the breakfast is good on the airline."
+TEXT: "The airline staff was really nice! Enjoyable flight."
+Output: {"answer": "no", "reasoning": "Although the text appreciates the flight experience, it DOES NOT mention about the breakfast."}
+
+PROPERTY: "appreciates the writing style of the author."
+TEXT: "The paper absolutely sucks because its underlying logic is wrong. However, the presentation of the paper is clear and the use of language is really impressive."
+Output: {"answer": "yes", "reasoning": "Although the text dislikes the paper, it says "the presentation of the paper is clear", so it DOES like the writing style."}
+
+PROPERTY: "has a formal style; specifically, the language in the text is relatively formal, complex and academic. For example, 'represent whom and which'"
+TEXT: "investigates formation of nominalization"
+Output: {"answer": "yes", "reasoning": "formation and nominalization are abstract and complex nouns."}
+
+PROPERTY: "refers to historical dates; specifically, there are references to years or specific dates in the text. For example, 'Obama was born on August 4, 1961.'"
+TEXT: "A member of the Democratic Party, he was the first African-American president of the United States."
+Output: {"answer": "no", "reasoning": "The text does not mention date."}

--- a/hypothesaes/prompts/annotate-user-json.txt
+++ b/hypothesaes/prompts/annotate-user-json.txt
@@ -1,0 +1,3 @@
+PROPERTY: "{hypothesis}"
+TEXT: "{text}"
+Output:

--- a/hypothesaes/select_neurons.py
+++ b/hypothesaes/select_neurons.py
@@ -161,10 +161,19 @@ def select_neurons_separation_score(
     scores = []
     for i in range(activations.shape[1]):
         neuron_acts = activations[:, i]
-        sorted_indices = np.argsort(-neuron_acts)
-        
-        # Get mean target value for top n activations
-        top_mean = np.mean(target[sorted_indices[:n_top_activating]])
+        nonzero_mask = neuron_acts >= 0
+
+        # Find all instances where activation is positive
+        nonzero_indices = np.where(nonzero_mask)[0]
+        n_positive = len(nonzero_indices)
+        sorted_nonzero_indices = nonzero_indices[np.argsort(-neuron_acts[nonzero_indices])]
+
+        # Get mean target value for top n activations, 0 if neuron is dead
+        top_mean = np.mean(target[sorted_nonzero_indices[:n_top_activating]]) if n_positive != 0 else 0
+
+        # Print warning message if fewer than n_top_activating positive activations
+        if n_positive < n_top_activating:
+            print(f"[WARNING] Only found {n_positive} examples with positive activation for neuron {i}, using all available to calculate separation score")
         
         # Get mean target value for zero activations
         zero_indices = neuron_acts == 0

--- a/tests/test_additional_annotations.py
+++ b/tests/test_additional_annotations.py
@@ -1,0 +1,33 @@
+import os
+
+import numpy as np
+import pytest
+
+from hypothesaes.annotate import annotate, parse_completion_json
+
+from .sentences import BLUE_SENTENCES, RED_SENTENCES
+
+if os.getenv('OPENAI_KEY_SAE') is None or os.getenv('OPENAI_KEY_SAE') == '...':
+    raise ValueError("Please set the OPENAI_KEY_SAE environment variable before running tests.")
+
+def _test_annotation(annotator_model):
+    blue_concept = "contains words associated with the color blue"
+    tasks = [(BLUE_SENTENCES[0], blue_concept), (RED_SENTENCES[0], blue_concept)]
+    annotations = annotate(
+        tasks,
+        model=annotator_model,
+        show_progress=False,
+        temperature=0.0,
+        parse_fn=parse_completion_json,
+        annotate_prompt_name='annotate-user-json',
+        system_prompt_name='annotate-system-json'
+    )
+    print(annotations)
+    assert blue_concept in annotations
+    assert BLUE_SENTENCES[0] in annotations[blue_concept]
+    assert RED_SENTENCES[0] in annotations[blue_concept]
+    assert annotations[blue_concept][BLUE_SENTENCES[0]] in (0, 1)
+    assert annotations[blue_concept][RED_SENTENCES[0]] in (0, 1)
+
+def test_openai_annotation():
+    _test_annotation("gpt-4.1-mini")


### PR DESCRIPTION
If neuron has fewer than top_n_activating positive activations, separation score currently pads the "top scores" with 0. Modified functionality so separation score computes its first term with only positive activations.